### PR TITLE
Fix CodeBuild runner docs and config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "description": "Automatically merge minor and patch-level updates",

--- a/README.md
+++ b/README.md
@@ -43,8 +43,25 @@ Installation
     (Replace `<project-name>` with the CodeBuild project name.)
 
     ```yaml
-    runs-on: codebuild-<project-name>-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on:
+      - codebuild-<project-name>-${{ github.run_id }}-${{ github.run_attempt }}
     ```
+
+    To override the project defaults for a specific job, add labels such as
+    `image:<environment-type>-<image-identifier>`,
+    `instance-size:<instance-size>`, `fleet:<fleet-name>`, and
+    `buildspec-override:true`.
+
+    ```yaml
+    runs-on:
+      - codebuild-<project-name>-${{ github.run_id }}-${{ github.run_attempt }}
+      - image:arm-3.0
+      - instance-size:small
+      - buildspec-override:true
+    ```
+
+    CodeBuild ignores the project buildspec for GitHub Actions jobs unless
+    `buildspec-override:true` is set.
 
 Cleanup
 -------

--- a/envs/root.hcl
+++ b/envs/root.hcl
@@ -68,7 +68,7 @@ inputs = {
   }
   iam_role_force_detach_policies                    = true
   github_repositories_requiring_codebuild           = ["dceoy/terraform-aws-github-oidc-and-runner"]
-  cloudwatch_logs_retention_in_days                 = 30
+  cloudwatch_logs_retention_in_days                 = 365
   codebuild_environment_type                        = "LINUX_CONTAINER"
   codebuild_environment_compute_type                = "BUILD_GENERAL1_SMALL"
   codebuild_environment_image                       = "aws/codebuild/standard:7.0"

--- a/envs/root.hcl
+++ b/envs/root.hcl
@@ -75,6 +75,6 @@ inputs = {
   codebuild_environment_image_pull_credentials_type = "CODEBUILD"
   codebuild_environment_privileged_mode             = false
   codebuild_build_timeout                           = 5
-  codebuild_queue_timeout                           = 5
+  codebuild_queued_timeout                          = 5
   # github_enterprise_slug                            = null
 }

--- a/modules/codebuild/variables.tf
+++ b/modules/codebuild/variables.tf
@@ -35,7 +35,7 @@ variable "kms_key_arn" {
 variable "cloudwatch_logs_retention_in_days" {
   description = "CloudWatch Logs retention in days"
   type        = number
-  default     = 30
+  default     = 365
   validation {
     condition     = contains([0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653], var.cloudwatch_logs_retention_in_days)
     error_message = "CloudWatch Logs retention in days must be 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653 or 0 (zero indicates never expire logs)"


### PR DESCRIPTION
## Summary
- fix the sample CodeBuild queued timeout input name in `envs/root.hcl`
- document current CodeBuild-hosted GitHub Actions `runs-on` label overrides in `README.md`
- note that project buildspecs are ignored unless `buildspec-override:true` is set

## Validation
- `terraform fmt -check -recursive`
- `git diff --check`
- `terragrunt hcl validate --working-dir envs --non-interactive` *(blocked locally by expired AWS credentials used by `get_aws_account_id()`)*